### PR TITLE
Add Lobby Chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# Mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,27 +10,33 @@ A Ravenfield multiplayer mod.
 ## This mod is very <b>W.I.P.</b> There are a lot of bugs and opportunities to crash, so please report anything you find!
 
 # Building
-There are several dependencies on game assemblies located in `Ravenfield/ravenfield_Data/Managed/`. To resolve them, create a `libs/` folder in the root folder and place the following assemblies there:
-- Assembly-CSharp.dll
-- Assembly-CSharp-firstpass.dll
-- netstandard.dll
-- UnityEngine.dll
-- UnityEngine.AnimationModule.dll
-- UnityEngine.AssetBundleModule.dll
-- UnityEngine.AudioModule.dll
-- UnityEngine.CoreModule.dll
-- UnityEngine.ImageConversionModule.dll
-- UnityEngine.IMGUIModule.dll
-- UnityEngine.InputLegacyModule.dll
-- UnityEngine.PhysicsModule.dll
-- UnityEngine.UI.dll
-- UnityEngine.UIModule.dll
 
-Afterwards, you should be able to build the project as normal. Visual Studio 2019+ is recommended. .NET 4.6 is required.
+Visual Studio 2019+ is recommended. .NET 4.6 is required.
+
+## Steps to build:
+
+1. Clone the repository to your local machine
+   
+   ```bash
+    $ git clone https://github.com/iliadsh/RavenM.git
+    $ git checkout master
+    ```
+
+2. Build project
+
+    ```bash
+    $ dotnet build RavenM
+    ```
+
+    Dependencies should be restored when building. If not, run the following command:
+
+    ```bash
+    $ dotnet restore
+    ```
 
 # Installing
 
-<b>Important Note:</b> RavenM does not support BepInEx version 6. Please ensure to install the latest version of BepInEx 5.x.x to complete the installation.
+<br>Important Note:</b> RavenM does not support BepInEx version 6. Please ensure to install the latest version of BepInEx 5.x.x to complete the installation.
 
 This mod depends on [BepInEx](https://github.com/BepInEx/BepInEx), a cross-platform Unity modding framework. First, install BepInEx into Ravenfield following the installation instructions [here](https://docs.bepinex.dev/articles/user_guide/installation/index.html). As per the instructions, make sure to run the game at least once with BepInEx installed before adding the mod to generate config files.
 
@@ -39,7 +45,10 @@ Next, place `RavenM.dll` into `Ravenfield/BepInEx/plugins/`. Optionally, you may
 Run the game and RavenM should now be installed.
 
 # Playing
+
 <b>Tl;dr</b>: The connection menu is opened with `M` while in the `Instant Action` menu.
+
+<b>Please be aware pirated/non-official copies of Ravenfield may encounter issues when using RavenM.</b> The mod relies entirely on Steam to transfer game data and mods securely between players.
 
 To play together, one player must be the host. This player will control the behaviour of all the bots, the game parameters, and the current game state. All other players will connect to the host during the match. Despite this, no port-forwarding is required! All data is routed through the Steam relay servers, which means fast, easy and encrypted connections with DDoS protection and Steam authentication.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Visual Studio 2019+ is recommended. .NET 4.6 is required.
 
 # Installing
 
-<br>Important Note:</b> RavenM does not support BepInEx version 6. Please ensure to install the latest version of BepInEx 5.x.x to complete the installation.
+<b>Important Note:</b> RavenM does not support BepInEx version 6. Please ensure to install the latest version of BepInEx 5.x.x to complete the installation.
 
 This mod depends on [BepInEx](https://github.com/BepInEx/BepInEx), a cross-platform Unity modding framework. First, install BepInEx into Ravenfield following the installation instructions [here](https://docs.bepinex.dev/articles/user_guide/installation/index.html). As per the instructions, make sure to run the game at least once with BepInEx installed before adding the mod to generate config files.
 

--- a/README.md
+++ b/README.md
@@ -9,31 +9,6 @@ A Ravenfield multiplayer mod.
 
 ## This mod is very <b>W.I.P.</b> There are a lot of bugs and opportunities to crash, so please report anything you find!
 
-# Building
-
-Visual Studio 2019+ is recommended. .NET 4.6 is required.
-
-## Steps to build:
-
-1. Clone the repository to your local machine
-   
-   ```bash
-    $ git clone https://github.com/iliadsh/RavenM.git
-    $ git checkout master
-    ```
-
-2. Build project
-
-    ```bash
-    $ dotnet build RavenM
-    ```
-
-    Dependencies should be restored when building. If not, run the following command:
-
-    ```bash
-    $ dotnet restore
-    ```
-
 # Installing
 
 <b>Important Note:</b> RavenM does not support BepInEx version 6. Please ensure to install the latest version of BepInEx 5.x.x to complete the installation.
@@ -59,6 +34,31 @@ Starting the game will put everyone in the lobby in a match and terminate the lo
 
 ## Joining
 Go to the `Instant Action` menu and press `M`. Press `Join` and paste the `Lobby ID` of an existing lobby. At this point, you cannot edit any of the options in the `Instant Action` page except for your team. You also cannot start the match. The settings chosen by the host will reflect on your own options.
+
+# Building from source
+
+Visual Studio 2019+ is recommended. .NET 4.6 is required.
+
+## Steps to build:
+
+1. Clone the repository to your local machine
+   
+   ```bash
+    $ git clone https://github.com/iliadsh/RavenM.git
+    $ git checkout master
+    ```
+
+2. Build project
+
+    ```bash
+    $ dotnet build RavenM
+    ```
+
+    Dependencies should be restored when building. If not, run the following command:
+
+    ```bash
+    $ dotnet restore
+    ```
 
 Have fun!
 

--- a/RavenM/ChatManager.cs
+++ b/RavenM/ChatManager.cs
@@ -1,0 +1,570 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using HarmonyLib;
+using Steamworks;
+using System.Collections;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using UnityEngine;
+using Ravenfield.SpecOps;
+using RavenM.Commands;
+
+namespace RavenM
+{
+    /// <summary>
+    /// Handles the display and backend for the Chat menu 
+    /// </summary>
+    public class ChatManager : MonoBehaviour
+    {
+        private string _currentChatMessage = string.Empty;
+        public string CurrentChatMessage
+        {
+            get { return _currentChatMessage; }
+            set { _currentChatMessage = value; }
+        }
+        private string _fullChatLink = string.Empty;
+        public string FullChatLink
+        {
+            get { return _fullChatLink; }
+            set { _fullChatLink = value; }
+        }
+        private Vector2 _chatScrollPosition = Vector2.zero;
+        public Vector2 ChatScrollPosition
+        {
+            get { return _chatScrollPosition; }
+            set { _chatScrollPosition = value; }
+        }
+        private Texture2D _greyBackground = new Texture2D(1, 1);
+        public Texture2D GreyBackground
+        {
+            get { return _greyBackground; }
+            set { _greyBackground = value; }
+        }
+        private bool _justFocused = false;
+        public bool JustFocused
+        {
+            get { return _justFocused; }
+            set { _justFocused = value; }
+        }
+        private bool _typeIntention = false;
+        public bool TypeIntention
+        {
+            get { return _typeIntention; }
+            set { _typeIntention = value; }
+        }
+        private bool _chatMode = false;
+        public bool ChatMode
+        {
+            get { return _chatMode; }
+            set { _chatMode = value; }
+        }
+        private CommandManager _commandManager;
+        public CommandManager CommandManager
+        {
+            get { return _commandManager; }
+            set { _commandManager = value; }
+        }
+        private KeyCode _globalChatKeybind = KeyCode.Y;
+        public KeyCode GlobalChatKeybind
+        {
+            get { return _globalChatKeybind; }
+            set { _globalChatKeybind = value; }
+        }
+        private KeyCode _teamChatKeybind = KeyCode.U;
+        public KeyCode TeamChatKeybind
+        {
+            get { return _teamChatKeybind; }
+            set { _teamChatKeybind = value; }
+        }
+        private CSteamID _steamId;
+        public CSteamID SteamId
+        {
+            get { return _steamId; }
+            set { _steamId = value; }
+        }
+        private string _steamUsername;
+        public string SteamUsername
+        {
+            get { return _steamUsername; }
+            private set { _steamUsername = value; }
+        }
+
+        public static ChatManager instance;
+
+        private void Awake()
+        {
+            instance = this;
+
+            GreyBackground.SetPixel(0, 0, Color.grey * 0.3f);
+            GreyBackground.Apply();
+
+            CommandManager = new CommandManager();
+
+            SteamId = SteamUser.GetSteamID();
+        }
+
+        private void Start()
+        {
+            Callback<LobbyChatUpdate_t>.Create(OnLobbyChatUpdate);
+            Callback<LobbyChatMsg_t>.Create(OnLobbyChatMessage);
+            Callback<PersonaStateChange_t>.Create(OnPersonaStateChange);
+        }
+
+        public void PushChatMessage(Actor actor, string message, bool global, int team)
+        {
+            string name;
+            if (actor != null)
+                name = actor.name;
+            else
+                name = "";
+            if (!global && GameManager.PlayerTeam() != team)
+                return;
+
+            if (team == -1)
+                FullChatLink += $"<color=#eeeeee>{message}</color>\n";
+            else
+            {
+                string color = !global ? "green" : (team == 0 ? "blue" : "red");
+                FullChatLink += $"<color={color}><b><{name}></b></color> {message}\n";
+                RSPatch.RavenscriptEventsManagerPatch.events.onReceiveChatMessage.Invoke(actor, message);
+            }
+
+            _chatScrollPosition.y = Mathf.Infinity;
+        }
+
+        private void OnPersonaStateChange(PersonaStateChange_t pCallback)
+        {
+            if (SteamId == (CSteamID)pCallback.m_ulSteamID)
+            {
+                SteamUsername = SteamFriends.GetFriendPersonaName(SteamId);
+            }
+        }
+
+        public void PushLobbyChatMessage(string message)
+        {
+            string name;
+            if (SteamUsername != null)
+                name = SteamUsername;
+            else
+                name = "";
+
+            // Players have no team in lobby so everyone is the same color
+            string color = "white";
+            FullChatLink += $"<color={color}><b><{name}></b></color> {message}\n";
+
+            _chatScrollPosition.y = Mathf.Infinity;
+        }
+
+        public void PushLobbyCommandChatMessage(string message, Color color, bool teamOnly, bool sendToAll)
+        {
+            FullChatLink += $"<color=#{ColorUtility.ToHtmlStringRGB(color)}><b>{message}</b></color>\n";
+            _chatScrollPosition.y = Mathf.Infinity;
+            if (!sendToAll)
+                return;
+            SendLobbyChat(message);
+        }
+
+        public void PushCommandChatMessage(string message, Color color, bool teamOnly, bool sendToAll)
+        {
+            FullChatLink += $"<color=#{ColorUtility.ToHtmlStringRGB(color)}><b>{message}</b></color>\n";
+            _chatScrollPosition.y = Mathf.Infinity;
+            if (!sendToAll)
+                return;
+            using MemoryStream memoryStream = new MemoryStream();
+            var chatPacket = new ChatPacket
+            {
+                Id = ActorManager.instance.player.GetComponent<GuidComponent>().guid,
+                Message = message,
+                TeamOnly = teamOnly,
+            };
+
+            using (var writer = new ProtocolWriter(memoryStream))
+            {
+                writer.Write(chatPacket);
+            }
+            byte[] data = memoryStream.ToArray();
+
+            IngameNetManager.instance.SendPacketToServer(data, PacketType.Chat, Constants.k_nSteamNetworkingSend_Reliable);
+        }
+
+        public void ProccessLobbyChatCommand(string message, ulong id, bool local)
+        {
+            string[] command = message.Trim().Substring(1, message.Length - 1).Split(' ');
+            string initCommand = command[0];
+            if (string.IsNullOrEmpty(initCommand))
+            {
+                return;
+            }
+            if (!CommandManager.ContainsCommand(initCommand))
+            {
+                PushLobbyCommandChatMessage($"No command with the name {initCommand} found.\nFor more information use Command /help", Color.red, false, false);
+                return;
+            }
+            Command cmd = CommandManager.GetCommandFromName(initCommand);
+            if (cmd == null)
+            {
+                Plugin.logger.LogError($"Command {initCommand} is not a registered Command!");
+                return;
+            }
+            bool hasCommandPermission = CommandManager.HasPermission(cmd, id, local);
+            // For Commands like /help that have reqArgs[0] = null we don't have to check for arguments
+            bool hasRequiredArgs = true;
+            if (cmd.reqArgs[0] != null)
+                hasRequiredArgs = CommandManager.HasRequiredArgs(cmd, command);
+            switch (cmd.CommandName)
+            {
+                case "nametags":
+
+                    if (!local)
+                    {
+                        UI.GameUI.instance.ToggleNameTags();
+                        PushLobbyCommandChatMessage("Set nametags to " + command[1], Color.green, false, false);
+                        return;
+                    }
+                    if (!hasCommandPermission || !hasRequiredArgs)
+                        return;
+                    bool parsedArg = bool.TryParse(command[1], out bool result);
+                    if (parsedArg)
+                    {
+                        SteamMatchmaking.SetLobbyData(LobbySystem.instance.ActualLobbyID, "nameTags", result.ToString());
+                        PushLobbyCommandChatMessage("Set nameTags to " + result.ToString(), Color.green, false, false);
+                        UI.GameUI.instance.ToggleNameTags();
+                    }
+
+                    break;
+                case "nametagsteamonly":
+
+                    if (!local)
+                    {
+                        UI.GameUI.instance.ToggleNameTags();
+                        PushLobbyCommandChatMessage("Set nameTags for Team only to " + command[1], Color.green, false, false);
+                        return;
+                    }
+                    if (!hasCommandPermission || !hasRequiredArgs)
+                        return;
+                    bool parsedArg2 = bool.TryParse(command[1], out bool result2);
+                    if (parsedArg2)
+                    {
+                        SteamMatchmaking.SetLobbyData(LobbySystem.instance.ActualLobbyID, "nameTagsForTeamOnly", result2.ToString());
+                        PushLobbyCommandChatMessage("Set nameTags for Team only to " + result2.ToString(), Color.green, false, false);
+                        UI.GameUI.instance.ToggleNameTags();
+                    }
+
+                    break;
+                case "help":
+                    foreach (Command availableCommand in CommandManager.GetAllCommands())
+                    {
+                        PushLobbyCommandChatMessage($"{CommandManager.GetRequiredArgTypes(availableCommand)} Host Only: {availableCommand.HostOnly}", availableCommand.Scripted ? Color.green : Color.yellow, true, false);
+                    }
+                    break;
+                default:
+                    // TODO: Allow other mods to handle commands from the lobby
+                    Plugin.logger.LogInfo("onReceiveCommand " + initCommand);
+                    break;
+            }
+
+            if (!cmd.Global == local)
+                return;
+
+            SendLobbyChat(message);
+        }
+
+        public void ProcessChatCommand(string message, Actor actor, ulong id, bool local)
+        {
+            string[] command = message.Trim().Substring(1, message.Length - 1).Split(' ');
+            string initCommand = command[0];
+            if (string.IsNullOrEmpty(initCommand))
+            {
+                return;
+            }
+            if (!CommandManager.ContainsCommand(initCommand))
+            {
+                PushCommandChatMessage($"No Command with name {initCommand} found.\nFor more information use Command /help", Color.red, false, false);
+                return;
+            }
+            Command cmd = CommandManager.GetCommandFromName(initCommand);
+            if (cmd == null)
+            {
+                Plugin.logger.LogError($"Command {initCommand} is not a registered Command!");
+                return;
+            }
+            bool hasCommandPermission = CommandManager.HasPermission(cmd, id, local);
+            // For Commands like /help that have reqArgs[0] = null we don't have to check for arguments
+            bool hasRequiredArgs = true;
+            if (cmd.reqArgs[0] != null)
+                hasRequiredArgs = CommandManager.HasRequiredArgs(cmd, command);
+            switch (cmd.CommandName)
+            {
+                case "nametags":
+
+                    if (!local)
+                    {
+                        UI.GameUI.instance.ToggleNameTags();
+                        PushCommandChatMessage("Set nametags to " + command[1], Color.green, false, false);
+                        return;
+                    }
+                    if (!hasCommandPermission || !hasRequiredArgs)
+                        return;
+                    bool parsedArg = bool.TryParse(command[1], out bool result);
+                    if (parsedArg)
+                    {
+                        SteamMatchmaking.SetLobbyData(LobbySystem.instance.ActualLobbyID, "nameTags", result.ToString());
+                        PushCommandChatMessage("Set nameTags to " + result.ToString(), Color.green, false, false);
+                        UI.GameUI.instance.ToggleNameTags();
+                    }
+
+                    break;
+                case "nametagsteamonly":
+
+                    if (!local)
+                    {
+                        UI.GameUI.instance.ToggleNameTags();
+                        PushCommandChatMessage("Set nameTags for Team only to " + command[1], Color.green, false, false);
+                        return;
+                    }
+                    if (!hasCommandPermission || !hasRequiredArgs)
+                        return;
+                    bool parsedArg2 = bool.TryParse(command[1], out bool result2);
+                    if (parsedArg2)
+                    {
+                        SteamMatchmaking.SetLobbyData(LobbySystem.instance.ActualLobbyID, "nameTagsForTeamOnly", result2.ToString());
+                        PushCommandChatMessage("Set nameTags for Team only to " + result2.ToString(), Color.green, false, false);
+                        UI.GameUI.instance.ToggleNameTags();
+                    }
+
+                    break;
+                case "help":
+                    foreach (Command availableCommand in CommandManager.GetAllCommands())
+                    {
+                        PushCommandChatMessage($"{CommandManager.GetRequiredArgTypes(availableCommand)} Host Only: {availableCommand.HostOnly}", availableCommand.Scripted ? Color.green : Color.yellow, true, false);
+                    }
+                    break;
+                case "kill":
+                    if (!hasCommandPermission || !hasRequiredArgs)
+                        return;
+                    string target = command[1];
+                    Actor targetActor = CommandManager.GetActorByName(target);
+                    if (targetActor == null)
+                    {
+                        return;
+                    }
+                    targetActor.Kill(new DamageInfo(DamageInfo.DamageSourceType.FallDamage, actor, null));
+                    PushCommandChatMessage($"Killed actor {targetActor.name}", Color.green, false, false);
+                    break;
+                default:
+                    // If it's not build in command pass it to RS
+                    Plugin.logger.LogInfo("onReceiveCommand " + initCommand);
+                    RSPatch.RavenscriptEventsManagerPatch.events.onReceiveCommand.Invoke(actor, command, new bool[] { hasCommandPermission, hasRequiredArgs, local });
+                    break;
+            }
+
+            if (!cmd.Global == local)
+                return;
+
+            using MemoryStream memoryStream = new MemoryStream();
+            var chatCommandPacket = new ChatCommandPacket
+            {
+                Id = ActorManager.instance.player.GetComponent<GuidComponent>().guid,
+                SteamID = SteamId.m_SteamID,
+                Command = CurrentChatMessage,
+                Scripted = cmd.Scripted,
+            };
+
+            using (var writer = new ProtocolWriter(memoryStream))
+            {
+                writer.Write(chatCommandPacket);
+            }
+            byte[] data = memoryStream.ToArray();
+            IngameNetManager.instance.SendPacketToServer(data, PacketType.ChatCommand, Constants.k_nSteamNetworkingSend_Reliable);
+        }
+
+        private void OnLobbyChatMessage(LobbyChatMsg_t pCallback)
+        {
+            var buf = new byte[4096];
+            int len = SteamMatchmaking.GetLobbyChatEntry(LobbySystem.instance.ActualLobbyID, (int)pCallback.m_iChatID, out CSteamID user, buf, buf.Length, out EChatEntryType chatType);
+            string chat = DecodeLobbyChat(buf, len);
+
+            if (chat.StartsWith("/") && user == LobbySystem.instance.OwnerID)
+            {
+                var parts = chat.Split(' ');
+                if (parts.Length < 1)
+                    return;
+                var command = parts[0];
+                if (command == "/kick")
+                {
+                    if (parts.Length != 2)
+                        return;
+                    var userIdS = parts[1];
+                    if (ulong.TryParse(userIdS, out ulong memberIdI))
+                    {
+                        var member = new CSteamID(memberIdI);
+                        if (member == SteamId)
+                        {
+                            LobbySystem.instance.NotificationText = "You were kicked from the lobby! You can no longer join this lobby.";
+                            SteamMatchmaking.LeaveLobby(LobbySystem.instance.ActualLobbyID);
+                        }
+                        else if (!LobbySystem.instance.CurrentKickedMembers.Contains(member))
+                        {
+                            LobbySystem.instance.CurrentKickedMembers.Add(member);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void OnLobbyChatUpdate(LobbyChatUpdate_t pCallback)
+        {
+            // Anything other than a join...
+            if ((pCallback.m_rgfChatMemberStateChange & (uint)EChatMemberStateChange.k_EChatMemberStateChangeEntered) == 0)
+            {
+                var id = new CSteamID(pCallback.m_ulSteamIDUserChanged);
+
+                // ...means the owner left.
+                if (LobbySystem.instance.OwnerID == id)
+                {
+                    LobbySystem.instance.NotificationText = "Lobby closed by host.";
+                    SteamMatchmaking.LeaveLobby(LobbySystem.instance.ActualLobbyID);
+                }
+            }
+            else
+            {
+                var id = new CSteamID(pCallback.m_ulSteamIDUserChanged);
+
+                if (LobbySystem.instance.CurrentKickedMembers.Contains(id))
+                {
+                    SendLobbyChat($"/kick {id}");
+                }
+            }
+        }
+
+        public void SendLobbyChat(string message)
+        {
+            var bytes = Encoding.UTF8.GetBytes(message);
+            SteamMatchmaking.SendLobbyChatMsg(LobbySystem.instance.ActualLobbyID, bytes, bytes.Length);
+        }
+
+        public string DecodeLobbyChat(byte[] bytes, int len)
+        {
+            // Don't want some a-hole crashing the lobby.
+            try
+            {
+                return Encoding.UTF8.GetString(bytes, 0, len);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        public void CreateChatArea(bool isLobbyChat = false)
+        {
+            if (Event.current.isKey && Event.current.keyCode == KeyCode.None && JustFocused)
+            {
+                Event.current.Use();
+                JustFocused = false;
+                return;
+            }
+
+            if (Event.current.isKey && (Event.current.keyCode == KeyCode.Tab || Event.current.character == '\t'))
+                Event.current.Use();
+
+            if (TypeIntention)
+            {
+                GUI.SetNextControlName("chat");
+                CurrentChatMessage = GUI.TextField(new Rect(10f, Screen.height - 160f, 500f, 25f), CurrentChatMessage);
+                GUI.FocusControl("chat");
+
+                string color = !ChatMode ? "green" : (GameManager.PlayerTeam() == 0 ? "blue" : "red");
+                string text = ChatMode ? "GLOBAL" : "TEAM";
+                GUI.Label(new Rect(510f, Screen.height - 160f, 70f, 25f), $"<color={color}><b>{text}</b></color>");
+
+                if (Event.current.isKey && Event.current.keyCode == KeyCode.Escape && TypeIntention)
+                {
+                    TypeIntention = false;
+                }
+
+                if (Event.current.isKey && Event.current.keyCode == KeyCode.Return)
+                {
+                    if (!string.IsNullOrEmpty(CurrentChatMessage))
+                    {
+                        bool isCommand = CurrentChatMessage.Trim().StartsWith("/") ? true : false;
+                        if (isCommand)
+                        {
+                            if (isLobbyChat)
+                            {
+                                ProccessLobbyChatCommand(CurrentChatMessage, SteamId.m_SteamID, true);
+                            }
+                            else
+                            {
+                                ProcessChatCommand(CurrentChatMessage, ActorManager.instance.player, SteamId.m_SteamID, true);
+                            }
+
+                            CurrentChatMessage = string.Empty;
+                        }
+                        else
+                        {
+                            if (isLobbyChat)
+                            {
+                                PushLobbyChatMessage(CurrentChatMessage);
+                                SendLobbyChat(CurrentChatMessage);
+                            }
+                            else
+                            {
+                                PushChatMessage(ActorManager.instance.player, CurrentChatMessage, ChatMode, GameManager.PlayerTeam());
+
+                                using MemoryStream memoryStream = new MemoryStream();
+                                var chatPacket = new ChatPacket
+                                {
+                                    Id = ActorManager.instance.player.GetComponent<GuidComponent>().guid,
+                                    Message = CurrentChatMessage,
+                                    TeamOnly = !ChatMode,
+                                };
+
+                                using (var writer = new ProtocolWriter(memoryStream))
+                                {
+                                    writer.Write(chatPacket);
+                                }
+                                byte[] data = memoryStream.ToArray();
+
+                                IngameNetManager.instance.SendPacketToServer(data, PacketType.Chat, Constants.k_nSteamNetworkingSend_Reliable);
+                            }
+
+                            CurrentChatMessage = string.Empty;
+                        }
+                    }
+                    TypeIntention = false;
+                }
+            }
+
+            if (Event.current.isKey && Event.current.keyCode == GlobalChatKeybind && !TypeIntention)
+            {
+                TypeIntention = true;
+                JustFocused = true;
+                ChatMode = true;
+            }
+
+            if (Event.current.isKey && Event.current.keyCode == TeamChatKeybind && !TypeIntention)
+            {
+                TypeIntention = true;
+                JustFocused = true;
+                ChatMode = false;
+            }
+
+            var chatStyle = new GUIStyle();
+            chatStyle.normal.background = GreyBackground;
+            GUILayout.BeginArea(new Rect(10f, Screen.height - 370f, 500f, 200f), string.Empty, chatStyle);
+            ChatScrollPosition = GUILayout.BeginScrollView(ChatScrollPosition, GUILayout.Width(500f), GUILayout.Height(200f));
+            // Any player can break the formatting by using Rich Text e.g. <color=abcd> <b> - Chai
+            GUILayout.Label(FullChatLink);
+            GUILayout.EndScrollView();
+            GUILayout.EndArea();
+        }
+    }
+}

--- a/RavenM/ChatManager.cs
+++ b/RavenM/ChatManager.cs
@@ -660,7 +660,7 @@ namespace RavenM
             chatStyle.normal.background = GreyBackground;
             
             var textStyle = new GUIStyle();
-            textStyle.wordWrap = true;
+            textStyle.wordWrap = wordWrap;
             textStyle.normal.textColor = Color.white;
             if (!wordWrap)
                 textStyle.wordWrap = false;

--- a/RavenM/ChatManager.cs
+++ b/RavenM/ChatManager.cs
@@ -668,7 +668,7 @@ namespace RavenM
             GUILayout.BeginArea(new Rect(10f, Screen.height - chatYOffset, chatWidth, chatHeight), string.Empty, chatStyle);
             GUILayout.BeginVertical();
             GUILayout.Space(10);
-            ChatScrollPosition = GUILayout.BeginScrollView(ChatScrollPosition, GUILayout.Width(500f), GUILayout.Height(200f));
+            ChatScrollPosition = GUILayout.BeginScrollView(ChatScrollPosition, GUILayout.Width(chatWidth), GUILayout.Height(chatHeight - 15f));
             // Any player can break the formatting by using Rich Text e.g. <color=abcd> <b> - Chai
             GUILayout.Label(FullChatLink, textStyle, GUILayout.Width(chatWidth - 30f));
             GUILayout.EndScrollView();

--- a/RavenM/ChatManager.cs
+++ b/RavenM/ChatManager.cs
@@ -112,11 +112,72 @@ namespace RavenM
 
         private void Start()
         {
-            Callback<LobbyChatUpdate_t>.Create(OnLobbyChatUpdate);
-            Callback<LobbyChatMsg_t>.Create(OnLobbyChatMessage);
             Callback<PersonaStateChange_t>.Create(OnPersonaStateChange);
+            Callback<LobbyChatMsg_t>.Create(OnLobbyChatMessage);
+            Callback<LobbyChatUpdate_t>.Create(OnLobbyChatUpdate);
         }
 
+        private void OnPersonaStateChange(PersonaStateChange_t pCallback)
+        {
+            if (SteamId == (CSteamID)pCallback.m_ulSteamID)
+            {
+                SteamUsername = SteamFriends.GetFriendPersonaName(SteamId);
+            }
+        }
+
+        private void OnLobbyChatMessage(LobbyChatMsg_t pCallback)
+        {
+            ulong steamId = pCallback.m_ulSteamIDUser;
+            var buf = new byte[4096];
+            int len = SteamMatchmaking.GetLobbyChatEntry(LobbySystem.instance.ActualLobbyID, (int)pCallback.m_iChatID, out CSteamID user, buf, buf.Length, out EChatEntryType chatType);
+            string chat = DecodeLobbyChat(buf, len);
+
+            if (steamId != SteamId.m_SteamID)
+            {
+                if (chat.StartsWith("/") && user == LobbySystem.instance.OwnerID)
+                {
+                    ProcessLobbyChatCommand(chat, SteamId.m_SteamID, true);
+                }
+                else
+                {
+                    PushLobbyChatMessage(chat, SteamFriends.GetFriendPersonaName((CSteamID)steamId));
+                }
+            }
+
+        }
+
+        private void OnLobbyChatUpdate(LobbyChatUpdate_t pCallback)
+        {
+            // Anything other than a join...
+            if ((pCallback.m_rgfChatMemberStateChange & (uint)EChatMemberStateChange.k_EChatMemberStateChangeEntered) == 0)
+            {
+                var id = new CSteamID(pCallback.m_ulSteamIDUserChanged);
+
+                // ...means the owner left.
+                if (LobbySystem.instance.OwnerID == id)
+                {
+                    LobbySystem.instance.NotificationText = "Lobby closed by host.";
+                    SteamMatchmaking.LeaveLobby(LobbySystem.instance.ActualLobbyID);
+                }
+            }
+            else
+            {
+                var id = new CSteamID(pCallback.m_ulSteamIDUserChanged);
+
+                if (LobbySystem.instance.CurrentKickedMembers.Contains(id))
+                {
+                    SendLobbyChat($"/kick {id}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Push message to chat transcript. Clients will not see messages here until sent
+        /// </summary>
+        /// <param name="actor"></param>
+        /// <param name="message"></param>
+        /// <param name="global"></param>
+        /// <param name="team"></param>
         public void PushChatMessage(Actor actor, string message, bool global, int team)
         {
             string name;
@@ -139,14 +200,12 @@ namespace RavenM
             _chatScrollPosition.y = Mathf.Infinity;
         }
 
-        private void OnPersonaStateChange(PersonaStateChange_t pCallback)
-        {
-            if (SteamId == (CSteamID)pCallback.m_ulSteamID)
-            {
-                SteamUsername = SteamFriends.GetFriendPersonaName(SteamId);
-            }
-        }
-
+        /// <summary>
+        /// Add message to chat transcipt without determining the client's team. Clients will not see messages here until sent
+        /// </summary>
+        /// <seealso cref="SendLobbyChat(string)"/>
+        /// <param name="message"></param>
+        /// <param name="steamUsername"></param>
         public void PushLobbyChatMessage(string message, string steamUsername)
         {
             // Players have no team in lobby so everyone is the same color
@@ -156,6 +215,24 @@ namespace RavenM
             _chatScrollPosition.y = Mathf.Infinity;
         }
 
+        /// <summary>
+        /// Sends a message without a username. Intended for messages directed at the player and not an actual chat message
+        /// </summary>
+        /// <param name="message"></param>
+        public void PushLobbyChatMessage(string message)
+        {
+            FullChatLink += $"{message}\n";
+
+            _chatScrollPosition.y = Mathf.Infinity;
+        }
+
+        /// <summary>
+        /// Sends command result back to clients and displays in chat area
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="color"></param>
+        /// <param name="teamOnly"></param>
+        /// <param name="sendToAll"></param>
         public void PushLobbyCommandChatMessage(string message, Color color, bool teamOnly, bool sendToAll)
         {
             FullChatLink += $"<color=#{ColorUtility.ToHtmlStringRGB(color)}><b>{message}</b></color>\n";
@@ -165,6 +242,13 @@ namespace RavenM
             SendLobbyChat(message);
         }
 
+        /// <summary>
+        /// Sends command result back to clients and displays in chat area
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="color"></param>
+        /// <param name="teamOnly"></param>
+        /// <param name="sendToAll"></param>
         public void PushCommandChatMessage(string message, Color color, bool teamOnly, bool sendToAll)
         {
             FullChatLink += $"<color=#{ColorUtility.ToHtmlStringRGB(color)}><b>{message}</b></color>\n";
@@ -188,6 +272,15 @@ namespace RavenM
             IngameNetManager.instance.SendPacketToServer(data, PacketType.Chat, Constants.k_nSteamNetworkingSend_Reliable);
         }
 
+        /// <summary>
+        /// Processes commands for lobby chat
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="id"></param>
+        /// <param name="local"></param>
+
+        // FIXME: This method should be part of the Command class
+        // and split so each command handles their own backend
         public void ProcessLobbyChatCommand(string message, ulong id, bool local)
         {
             string[] command = message.Trim().Substring(1, message.Length - 1).Split(' ');
@@ -207,11 +300,19 @@ namespace RavenM
                 Plugin.logger.LogError($"Command {initCommand} is not a registered Command!");
                 return;
             }
+
+            if (!cmd.AllowInLobby)
+            {
+                PushLobbyCommandChatMessage(cmd.AllowInGame ? "This command is not allowed in the lobby!" : "This command is disabled!", Color.red, true, false);
+                return;
+            }
+
             bool hasCommandPermission = CommandManager.HasPermission(cmd, id, local);
             // For Commands like /help that have reqArgs[0] = null we don't have to check for arguments
             bool hasRequiredArgs = true;
             if (cmd.reqArgs[0] != null)
                 hasRequiredArgs = CommandManager.HasRequiredArgs(cmd, command);
+
             switch (cmd.CommandName)
             {
                 case "nametags":
@@ -276,7 +377,7 @@ namespace RavenM
                     break;
                 default:
                     // TODO: Allow other mods to handle commands from the lobby
-                    Plugin.logger.LogInfo("onReceiveCommand " + initCommand);
+                    Plugin.logger.LogInfo("Lobby onReceiveCommand " + initCommand);
                     break;
             }
 
@@ -286,6 +387,16 @@ namespace RavenM
             SendLobbyChat(message);
         }
 
+        /// <summary>
+        /// Processess commands for ingame chat
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="actor"></param>
+        /// <param name="id"></param>
+        /// <param name="local"></param>
+        
+        // FIXME: This method should be part of the Command class
+        // and split so each command handles their own backend
         public void ProcessChatCommand(string message, Actor actor, ulong id, bool local)
         {
             string[] command = message.Trim().Substring(1, message.Length - 1).Split(' ');
@@ -351,7 +462,7 @@ namespace RavenM
 
                     break;
                 case "help":
-                    foreach (Command availableCommand in CommandManager.GetAllCommands())
+                    foreach (Command availableCommand in CommandManager.GetAllIngameCommands())
                     {
                         PushCommandChatMessage($"{CommandManager.GetRequiredArgTypes(availableCommand)} Host Only: {availableCommand.HostOnly}", availableCommand.Scripted ? Color.green : Color.yellow, true, false);
                     }
@@ -386,7 +497,7 @@ namespace RavenM
                     break;
                 default:
                     // If it's not build in command pass it to RS
-                    Plugin.logger.LogInfo("onReceiveCommand " + initCommand);
+                    Plugin.logger.LogInfo("Ingame onReceiveCommand " + initCommand);
                     RSPatch.RavenscriptEventsManagerPatch.events.onReceiveCommand.Invoke(actor, command, new bool[] { hasCommandPermission, hasRequiredArgs, local });
                     break;
             }
@@ -411,52 +522,10 @@ namespace RavenM
             IngameNetManager.instance.SendPacketToServer(data, PacketType.ChatCommand, Constants.k_nSteamNetworkingSend_Reliable);
         }
 
-        private void OnLobbyChatMessage(LobbyChatMsg_t pCallback)
-        {
-            ulong steamId = pCallback.m_ulSteamIDUser;
-            var buf = new byte[4096];
-            int len = SteamMatchmaking.GetLobbyChatEntry(LobbySystem.instance.ActualLobbyID, (int)pCallback.m_iChatID, out CSteamID user, buf, buf.Length, out EChatEntryType chatType);
-            string chat = DecodeLobbyChat(buf, len);
-
-            if (steamId != SteamId.m_SteamID)
-            {
-                if (chat.StartsWith("/") && user == LobbySystem.instance.OwnerID)
-                {
-                    ProcessLobbyChatCommand(chat, SteamId.m_SteamID, true);
-                }
-                else
-                {
-                    PushLobbyChatMessage(chat, SteamFriends.GetFriendPersonaName((CSteamID)steamId));
-                }
-            }
-
-        }
-
-        private void OnLobbyChatUpdate(LobbyChatUpdate_t pCallback)
-        {
-            // Anything other than a join...
-            if ((pCallback.m_rgfChatMemberStateChange & (uint)EChatMemberStateChange.k_EChatMemberStateChangeEntered) == 0)
-            {
-                var id = new CSteamID(pCallback.m_ulSteamIDUserChanged);
-
-                // ...means the owner left.
-                if (LobbySystem.instance.OwnerID == id)
-                {
-                    LobbySystem.instance.NotificationText = "Lobby closed by host.";
-                    SteamMatchmaking.LeaveLobby(LobbySystem.instance.ActualLobbyID);
-                }
-            }
-            else
-            {
-                var id = new CSteamID(pCallback.m_ulSteamIDUserChanged);
-
-                if (LobbySystem.instance.CurrentKickedMembers.Contains(id))
-                {
-                    SendLobbyChat($"/kick {id}");
-                }
-            }
-        }
-
+        /// <summary>
+        /// Sends a message directly to Steam. Messages sent here are not displayed in the chat area
+        /// </summary>
+        /// <param name="message"></param>
         public void SendLobbyChat(string message)
         {
             var bytes = Encoding.UTF8.GetBytes(message);
@@ -476,6 +545,11 @@ namespace RavenM
             }
         }
 
+        /// <summary>
+        /// Creates the events for interacting with the chat area
+        /// </summary>
+        /// <param name="isLobbyChat"></param>
+        /// <param name="chatWidth"></param>
         public void InitializeChatArea(bool isLobbyChat = false, float chatWidth = 500f)
         {
             if (Event.current.isKey && Event.current.keyCode == KeyCode.None && JustFocused)
@@ -571,18 +645,41 @@ namespace RavenM
             }
         }
 
-        public void CreateChatArea(bool isLobbyChat = false, float chatWidth = 500f, float chatHeight = 200f, float chatYOffset = 370f)
+        /// <summary>
+        /// Draws the chat area
+        /// </summary>
+        /// <param name="isLobbyChat"></param>
+        /// <param name="chatWidth"></param>
+        /// <param name="chatHeight"></param>
+        /// <param name="chatYOffset"></param>
+        public void CreateChatArea(bool isLobbyChat = false, float chatWidth = 500f, float chatHeight = 200f, float chatYOffset = 370f, bool wordWrap = true)
         {
             InitializeChatArea(isLobbyChat, chatWidth);
 
             var chatStyle = new GUIStyle();
             chatStyle.normal.background = GreyBackground;
+            
+            var textStyle = new GUIStyle();
+            textStyle.wordWrap = true;
+            textStyle.normal.textColor = Color.white;
+            if (!wordWrap)
+                textStyle.wordWrap = false;
+                
             GUILayout.BeginArea(new Rect(10f, Screen.height - chatYOffset, chatWidth, chatHeight), string.Empty, chatStyle);
+            GUILayout.BeginVertical();
+            GUILayout.Space(10);
             ChatScrollPosition = GUILayout.BeginScrollView(ChatScrollPosition, GUILayout.Width(500f), GUILayout.Height(200f));
             // Any player can break the formatting by using Rich Text e.g. <color=abcd> <b> - Chai
-            GUILayout.Label(FullChatLink);
+            GUILayout.Label(FullChatLink, textStyle, GUILayout.Width(chatWidth - 30f));
             GUILayout.EndScrollView();
+            GUILayout.Space(10);
+            GUILayout.EndVertical();
             GUILayout.EndArea();
+        }
+
+        public void ResetChat()
+        {
+            FullChatLink = string.Empty;
         }
     }
 }

--- a/RavenM/Commands/Command.cs
+++ b/RavenM/Commands/Command.cs
@@ -8,13 +8,13 @@ namespace RavenM.Commands
 {
     public class Command
     {
-        public string CommandName { get; }
-        public object[] reqArgs { get; }
-        public bool Global { get; }
-        public bool HostOnly { get; }
-        public bool Scripted { get; }
-        public bool AllowInLobby { get; }
-        public bool AllowInGame { get;  }
+        public string CommandName { get; set; }
+        public object[] reqArgs { get; set; }
+        public bool Global { get; set; }
+        public bool HostOnly { get; set; }
+        public bool Scripted { get; set; }
+        public bool AllowInLobby { get; set; }
+        public bool AllowInGame { get; set; }
         public Command(string _name, object[] _reqArgs,bool _global, bool _hostOnly, bool scripted = false, bool allowInLobby = false, bool allowInGame = true)
         {
             CommandName = _name;

--- a/RavenM/Commands/Command.cs
+++ b/RavenM/Commands/Command.cs
@@ -13,13 +13,17 @@ namespace RavenM.Commands
         public bool Global { get; }
         public bool HostOnly { get; }
         public bool Scripted { get; }
-        public Command(string _name, object[] _reqArgs,bool _global, bool _hostOnly, bool scripted = false)
+        public bool AllowInLobby { get; }
+        public bool AllowInGame { get;  }
+        public Command(string _name, object[] _reqArgs,bool _global, bool _hostOnly, bool scripted = false, bool allowInLobby = false, bool allowInGame = true)
         {
             CommandName = _name;
             reqArgs = _reqArgs;
             Global = _global;
             HostOnly = _hostOnly;
             Scripted = scripted;
+            AllowInLobby = allowInLobby;
+            AllowInGame = allowInGame;
         }
 
     }

--- a/RavenM/Commands/CommandManager.cs
+++ b/RavenM/Commands/CommandManager.cs
@@ -14,11 +14,51 @@ namespace RavenM.Commands
         public CommandManager()
         {
             Commands = new List<Command>();
-            Commands.Add(new Command("help", new object[] { null }, false, false, true, true));
-            Commands.Add(new Command("nametags", new object[] { true }, true, true, true, true));
-            Commands.Add(new Command("kill", new object[] { "actor" }, true, true, false, true));
-            Commands.Add(new Command("nametagsteamonly", new object[] { true }, true, true, true, true));
-            Commands.Add(new Command("kick", new object[] { "actor" }, false, true, false, true));
+            Commands.Add(new Command(
+                _name: "help",
+                _reqArgs: new object[] { null }, 
+                _global: false, 
+                _hostOnly: false, 
+                scripted: true,
+                allowInLobby: true,
+                allowInGame: true)
+            );
+            Commands.Add(new Command(
+                _name: "nametags",
+                _reqArgs: new object[] { true },
+                _global: true, 
+                _hostOnly: true, 
+                scripted: true, 
+                allowInLobby: true,
+                allowInGame: true)
+            );
+            Commands.Add(new Command(
+                _name: "kill", 
+                _reqArgs: new object[] { "actor" }, 
+                _global: true, 
+                _hostOnly: true, 
+                scripted: false, 
+                allowInLobby: false, 
+                allowInGame: true)
+            );
+            Commands.Add(new Command(
+                _name: "nametagsteamonly", 
+                _reqArgs: new object[] { true }, 
+                _global: true, 
+                _hostOnly: true, 
+                scripted: true, 
+                allowInLobby: true,
+                allowInGame: true)
+            );
+            Commands.Add(new Command(
+                _name: "kick", 
+                _reqArgs: new object[] { "actor" },
+                _global: false,
+                _hostOnly: true,
+                scripted: true,
+                allowInLobby: true,
+                allowInGame: true)
+            );
             Plugin.logger.LogInfo("CommandManager registered commands: " + Commands.Count);
         }
         public Command GetCommandFromName(string command)
@@ -42,19 +82,11 @@ namespace RavenM.Commands
         }
         public List<Command> GetAllLobbyCommands()
         {
-            IEnumerable<Command> commands = Commands;
-
-            commands = commands.Where(command => command.AllowInLobby == true);
-
-            return commands.ToList();
+            return Commands.Where(command => command.AllowInLobby == true).ToList();
         }
         public List<Command> GetAllIngameCommands()
         {
-            IEnumerable<Command> commands = Commands;
-
-            commands = commands.Where(command => command.AllowInGame == true);
-
-            return commands.ToList();
+            return Commands.Where(command => command.AllowInGame == true).ToList();
         }
         public void AddCustomCommand(Command cmd)
         {

--- a/RavenM/Commands/CommandManager.cs
+++ b/RavenM/Commands/CommandManager.cs
@@ -14,10 +14,11 @@ namespace RavenM.Commands
         public CommandManager()
         {
             Commands = new List<Command>();
-            Commands.Add(new Command("help",new object[] { null },false,false));
-            Commands.Add(new Command("nametags", new object[] { true }, true, true));
-            Commands.Add(new Command("kill", new object[] { "actor" }, true, true));
-            Commands.Add(new Command("nametagsteamonly", new object[] { true }, true, true));
+            Commands.Add(new Command("help", new object[] { null }, false, false, true, true));
+            Commands.Add(new Command("nametags", new object[] { true }, true, true, true, true));
+            Commands.Add(new Command("kill", new object[] { "actor" }, true, true, false, true));
+            Commands.Add(new Command("nametagsteamonly", new object[] { true }, true, true, true, true));
+            Commands.Add(new Command("kick", new object[] { "actor" }, false, true, false, true));
             Plugin.logger.LogInfo("CommandManager registered commands: " + Commands.Count);
         }
         public Command GetCommandFromName(string command)
@@ -38,6 +39,22 @@ namespace RavenM.Commands
         public List<Command> GetAllCommands()
         {
             return Commands;
+        }
+        public List<Command> GetAllLobbyCommands()
+        {
+            IEnumerable<Command> commands = Commands;
+
+            commands = commands.Where(command => command.AllowInLobby == true);
+
+            return commands.ToList();
+        }
+        public List<Command> GetAllIngameCommands()
+        {
+            IEnumerable<Command> commands = Commands;
+
+            commands = commands.Where(command => command.AllowInGame == true);
+
+            return commands.ToList();
         }
         public void AddCustomCommand(Command cmd)
         {

--- a/RavenM/Commands/CommandManager.cs
+++ b/RavenM/Commands/CommandManager.cs
@@ -69,11 +69,11 @@ namespace RavenM.Commands
         }
         private void PrintNotEnoughArguments(Command cmd)
         {
-            IngameNetManager.instance.PushCommandChatMessage($"Not enough Arguments for Command {cmd.CommandName}. \nUsage: {GetRequiredArgTypes(cmd)}.", Color.red,true, false); ;
+            ChatManager.instance.PushCommandChatMessage($"Not enough Arguments for Command {cmd.CommandName}. \nUsage: {GetRequiredArgTypes(cmd)}.", Color.red,true, false); ;
         }
         private void PrintCouldNotConvert(Command cmd)
         {
-            IngameNetManager.instance.PushCommandChatMessage($"Could not convert Argument(s) for Command {cmd.CommandName}. \nUsage: {GetRequiredArgTypes(cmd)}.", Color.red,true, false); ;
+            ChatManager.instance.PushCommandChatMessage($"Could not convert Argument(s) for Command {cmd.CommandName}. \nUsage: {GetRequiredArgTypes(cmd)}.", Color.red,true, false); ;
         }
         public bool HasRequiredArgs(Command cmd, string[] command)
         {
@@ -156,7 +156,7 @@ namespace RavenM.Commands
             }
             if (local == !command.Global)
                 return true;
-            IngameNetManager.instance.PushCommandChatMessage($"You do not have permission to run this command!", Color.red, false, false);
+            ChatManager.instance.PushCommandChatMessage($"You do not have permission to run this command!", Color.red, false, false);
             return false;
         }
     }

--- a/RavenM/IngameNetManager.cs
+++ b/RavenM/IngameNetManager.cs
@@ -32,6 +32,7 @@ namespace RavenM
                 SteamNetworkingSockets.CloseListenSocket(IngameNetManager.instance.ServerSocket);
 
             IngameNetManager.instance.ResetState();
+            ChatManager.instance.ResetChat();
         }
     }
 
@@ -765,7 +766,6 @@ namespace RavenM
             MarkerPosition = Vector3.zero;
 
             ChatManager.instance.CurrentChatMessage = string.Empty;
-            ChatManager.instance.FullChatLink = string.Empty;
             ChatManager.instance.ChatScrollPosition = Vector2.zero;
             ChatManager.instance.JustFocused = false;
             ChatManager.instance.TypeIntention = false;
@@ -2115,8 +2115,16 @@ namespace RavenM
                                     var commandPacket = dataStream.ReadChatCommandPacket();
 
                                     var actor = ClientActors.ContainsKey(commandPacket.Id) ? ClientActors[commandPacket.Id] : null;
-                                    if (actor != null)
-                                        ChatManager.instance.ProcessChatCommand(commandPacket.Command, actor,commandPacket.SteamID, false);
+                                    bool inLobby = LobbySystem.instance.InLobby;
+
+                                    if (!inLobby && actor != null)
+                                    {
+                                         ChatManager.instance.ProcessChatCommand(commandPacket.Command, actor, commandPacket.SteamID, false);
+                                    }
+                                    else
+                                    {
+                                        ChatManager.instance.ProcessLobbyChatCommand(commandPacket.Command, commandPacket.SteamID, false);
+                                    }
 
                                 }
                                 break;

--- a/RavenM/IngameNetManager.cs
+++ b/RavenM/IngameNetManager.cs
@@ -765,7 +765,7 @@ namespace RavenM
             MarkerPosition = Vector3.zero;
 
             ChatManager.instance.CurrentChatMessage = string.Empty;
-            //ChatManager.instance.FullChatLink = string.Empty;
+            ChatManager.instance.FullChatLink = string.Empty;
             ChatManager.instance.ChatScrollPosition = Vector2.zero;
             ChatManager.instance.JustFocused = false;
             ChatManager.instance.TypeIntention = false;

--- a/RavenM/IngameNetManager.cs
+++ b/RavenM/IngameNetManager.cs
@@ -478,20 +478,6 @@ namespace RavenM
 
         public Vector3 MarkerPosition = Vector3.zero;
 
-        //public string CurrentChatMessage = string.Empty;
-
-        //public string FullChatLink = string.Empty;
-
-        //public Vector2 ChatScrollPosition = Vector2.zero;
-
-        //public Texture2D GreyBackground = new Texture2D(1, 1);
-
-        //public bool JustFocused = false;
-
-        //public bool TypeIntention = false;
-
-        //public bool ChatMode = false;
-
         public bool UsingMicrophone = false;
 
         public Texture2D MicTexture = new Texture2D(2, 2);
@@ -512,9 +498,6 @@ namespace RavenM
 
         public KeyCode PlaceMarkerKeybind = KeyCode.BackQuote;
 
-        //public KeyCode GlobalChatKeybind = KeyCode.Y;
-
-        //public KeyCode TeamChatKeybind = KeyCode.U;
         private void Awake()
         {
             instance = this;
@@ -782,7 +765,7 @@ namespace RavenM
             MarkerPosition = Vector3.zero;
 
             ChatManager.instance.CurrentChatMessage = string.Empty;
-            ChatManager.instance.FullChatLink = string.Empty;
+            //ChatManager.instance.FullChatLink = string.Empty;
             ChatManager.instance.ChatScrollPosition = Vector2.zero;
             ChatManager.instance.JustFocused = false;
             ChatManager.instance.TypeIntention = false;

--- a/RavenM/IngameNetManager.cs
+++ b/RavenM/IngameNetManager.cs
@@ -478,19 +478,19 @@ namespace RavenM
 
         public Vector3 MarkerPosition = Vector3.zero;
 
-        public string CurrentChatMessage = string.Empty;
+        //public string CurrentChatMessage = string.Empty;
 
-        public string FullChatLink = string.Empty;
+        //public string FullChatLink = string.Empty;
 
-        public Vector2 ChatScrollPosition = Vector2.zero;
+        //public Vector2 ChatScrollPosition = Vector2.zero;
 
-        public Texture2D GreyBackground = new Texture2D(1, 1);
+        //public Texture2D GreyBackground = new Texture2D(1, 1);
 
-        public bool JustFocused = false;
+        //public bool JustFocused = false;
 
-        public bool TypeIntention = false;
+        //public bool TypeIntention = false;
 
-        public bool ChatMode = false;
+        //public bool ChatMode = false;
 
         public bool UsingMicrophone = false;
 
@@ -502,7 +502,6 @@ namespace RavenM
 
         public CommandManager commandManager;
 
-
         public Type Steamworks_NativeMethods;
 
         public MethodInfo SteamAPI_SteamNetworkingMessage_t_Release;
@@ -513,9 +512,9 @@ namespace RavenM
 
         public KeyCode PlaceMarkerKeybind = KeyCode.BackQuote;
 
-        public KeyCode GlobalChatKeybind = KeyCode.Y;
+        //public KeyCode GlobalChatKeybind = KeyCode.Y;
 
-        public KeyCode TeamChatKeybind = KeyCode.U;
+        //public KeyCode TeamChatKeybind = KeyCode.U;
         private void Awake()
         {
             instance = this;
@@ -527,8 +526,8 @@ namespace RavenM
 
             MarkerTexture.LoadImage(imageBytes);
 
-            GreyBackground.SetPixel(0, 0, Color.grey * 0.3f);
-            GreyBackground.Apply();
+            ChatManager.instance.GreyBackground.SetPixel(0, 0, Color.grey * 0.3f);
+            ChatManager.instance.GreyBackground.Apply();
 
             using var micResource = Assembly.GetExecutingAssembly().GetManifestResourceStream("RavenM.assets.mic.png");
             resourceMemory.SetLength(0);
@@ -743,245 +742,13 @@ namespace RavenM
                     continue;
                 DrawMarker(controller.Targets.MarkerPosition ?? Vector3.zero);
             }
-            if (Event.current.isKey && Event.current.keyCode == KeyCode.None && JustFocused)
-            {
-                Event.current.Use();
-                JustFocused = false;
-                return;
-            }
 
-            if (Event.current.isKey && (Event.current.keyCode == KeyCode.Tab || Event.current.character == '\t'))
-                Event.current.Use();
-
-            if (TypeIntention)
-            {
-                GUI.SetNextControlName("chat");
-                CurrentChatMessage = GUI.TextField(new Rect(10f, Screen.height - 160f, 500f, 25f), CurrentChatMessage);
-                GUI.FocusControl("chat");
-
-                string color = !ChatMode ? "green" : (GameManager.PlayerTeam() == 0 ? "blue" : "red");
-                string text = ChatMode ? "GLOBAL" : "TEAM";
-                GUI.Label(new Rect(510f, Screen.height - 160f, 70f, 25f), $"<color={color}><b>{text}</b></color>");
-
-                if (Event.current.isKey && Event.current.keyCode == KeyCode.Escape && TypeIntention)
-                {
-                    TypeIntention = false;
-                }
-
-                if (Event.current.isKey && Event.current.keyCode == KeyCode.Return)
-                {
-                    if (!string.IsNullOrEmpty(CurrentChatMessage))
-                    {
-                        bool isCommand = CurrentChatMessage.Trim().StartsWith("/") ? true : false;
-                        if (isCommand)
-                        {
-                            ProcessChatCommand(CurrentChatMessage, ActorManager.instance.player,SteamUser.GetSteamID().m_SteamID, true);
-                            CurrentChatMessage = string.Empty;
-                        }
-                        else
-                        {
-
-                            PushChatMessage(ActorManager.instance.player, CurrentChatMessage, ChatMode, GameManager.PlayerTeam());
-
-                            using MemoryStream memoryStream = new MemoryStream();
-                            var chatPacket = new ChatPacket
-                            {
-                                Id = ActorManager.instance.player.GetComponent<GuidComponent>().guid,
-                                Message = CurrentChatMessage,
-                                TeamOnly = !ChatMode,
-                            };
-
-                            using (var writer = new ProtocolWriter(memoryStream))
-                            {
-                                writer.Write(chatPacket);
-                            }
-                            byte[] data = memoryStream.ToArray();
-
-                            SendPacketToServer(data, PacketType.Chat, Constants.k_nSteamNetworkingSend_Reliable);
-
-                            CurrentChatMessage = string.Empty;
-                        }
-                    }
-                    TypeIntention = false;
-                }
-            }
-
-            if (Event.current.isKey && Event.current.keyCode == GlobalChatKeybind && !TypeIntention)
-            {
-                TypeIntention = true;
-                JustFocused = true;
-                ChatMode = true;
-            }
-
-            if (Event.current.isKey && Event.current.keyCode == TeamChatKeybind && !TypeIntention)
-            {
-                TypeIntention = true;
-                JustFocused = true;
-                ChatMode = false;
-            }
-
-            var chatStyle = new GUIStyle();
-            chatStyle.normal.background = GreyBackground;
-            GUILayout.BeginArea(new Rect(10f, Screen.height - 370f, 500f, 200f), string.Empty, chatStyle);
-            ChatScrollPosition = GUILayout.BeginScrollView(ChatScrollPosition, GUILayout.Width(500f), GUILayout.Height(200f));
-            // Any player can break the formatting by using Rich Text e.g. <color=abcd> <b> - Chai
-            GUILayout.Label(FullChatLink);
-            GUILayout.EndScrollView();
-            GUILayout.EndArea();
+            ChatManager.instance.CreateChatArea(false);
 
             if (UsingMicrophone)
                 GUI.DrawTexture(new Rect(315f, Screen.height - 60f, 50f, 50f), MicTexture);
         }
 
-        public void PushChatMessage(Actor actor, string message, bool global, int team)
-        {
-            string name;
-            if (actor != null)
-                name = actor.name;
-            else
-                name = "";
-            if (!global && GameManager.PlayerTeam() != team)
-                return;
-
-            if (team == -1)
-                FullChatLink += $"<color=#eeeeee>{message}</color>\n";
-            else
-            {
-                string color = !global ? "green" : (team == 0 ? "blue" : "red");
-                FullChatLink += $"<color={color}><b><{name}></b></color> {message}\n";
-                RSPatch.RavenscriptEventsManagerPatch.events.onReceiveChatMessage.Invoke(actor, message);
-            }
-
-            ChatScrollPosition.y = Mathf.Infinity;
-        }
-        public void PushCommandChatMessage(string message,Color color, bool teamOnly,bool sendToAll)
-        {
-
-            FullChatLink += $"<color=#{ColorUtility.ToHtmlStringRGB(color)}><b>{message}</b></color>\n";
-            ChatScrollPosition.y = Mathf.Infinity;
-            if (!sendToAll)
-                   return;
-            using MemoryStream memoryStream = new MemoryStream();
-            var chatPacket = new ChatPacket
-            {
-                Id = ActorManager.instance.player.GetComponent<GuidComponent>().guid,
-                Message = message,
-                TeamOnly = teamOnly,
-            };
-
-            using (var writer = new ProtocolWriter(memoryStream))
-            {
-                writer.Write(chatPacket);
-            }
-            byte[] data = memoryStream.ToArray();
-
-            SendPacketToServer(data, PacketType.Chat, Constants.k_nSteamNetworkingSend_Reliable);
-        }
-        private void ProcessChatCommand(string message, Actor actor,ulong id, bool local)
-        {
-            string[] command = message.Trim().Substring(1, message.Length - 1).Split(' ');
-            string initCommand = command[0];
-            if (string.IsNullOrEmpty(initCommand))
-            {
-                return;
-            }
-            if (!commandManager.ContainsCommand(initCommand))
-            {
-                PushCommandChatMessage($"No Command with name {initCommand} found.\nFor more information use Command /help", Color.red, false, false);
-                return;
-            }
-            Command cmd = commandManager.GetCommandFromName(initCommand);
-            if (cmd == null) {
-                Plugin.logger.LogError($"Command {initCommand} is not a registered Command!");
-                return;
-            }
-            bool hasCommandPermission = commandManager.HasPermission(cmd, id, local);
-            // For Commands like /help that have reqArgs[0] = null we don't have to check for arguments
-            bool hasRequiredArgs = true;
-            if (cmd.reqArgs[0] != null)
-                hasRequiredArgs = commandManager.HasRequiredArgs(cmd, command);
-            switch (cmd.CommandName)
-            {
-                case "nametags":
-
-                    if (!local)
-                    {
-                        UI.GameUI.instance.ToggleNameTags();
-                        PushCommandChatMessage("Set nametags to " + command[1], Color.green, false, false);
-                        return;
-                    }
-                    if (!hasCommandPermission || !hasRequiredArgs)
-                        return;
-                    bool parsedArg = bool.TryParse(command[1], out bool result);
-                    if (parsedArg)
-                    {
-                        SteamMatchmaking.SetLobbyData(LobbySystem.instance.ActualLobbyID, "nameTags", result.ToString());
-                        PushCommandChatMessage("Set nameTags to " + result.ToString(), Color.green,false,false);
-                        UI.GameUI.instance.ToggleNameTags();
-                    }
-                    
-                    break;
-                case "nametagsteamonly":
-
-                    if (!local)
-                    {
-                        UI.GameUI.instance.ToggleNameTags();
-                        PushCommandChatMessage("Set nameTags for Team only to " + command[1], Color.green, false, false);
-                        return;
-                    }
-                    if (!hasCommandPermission || !hasRequiredArgs)
-                        return;
-                    bool parsedArg2 = bool.TryParse(command[1], out bool result2);
-                    if (parsedArg2)
-                    {
-                        SteamMatchmaking.SetLobbyData(LobbySystem.instance.ActualLobbyID, "nameTagsForTeamOnly", result2.ToString());
-                        PushCommandChatMessage("Set nameTags for Team only to " + result2.ToString(), Color.green, false, false);
-                        UI.GameUI.instance.ToggleNameTags();
-                    }
-
-                    break;
-                case "help":
-                    foreach(Command availableCommand in commandManager.GetAllCommands())
-                    {
-                        PushCommandChatMessage($"{commandManager.GetRequiredArgTypes(availableCommand)} Host Only: {availableCommand.HostOnly}", availableCommand.Scripted ? Color.green: Color.yellow, true, false);
-                    }
-                    break;
-                case "kill":
-                    if (!hasCommandPermission || !hasRequiredArgs)
-                        return;
-                    string target = command[1];
-                    Actor targetActor = commandManager.GetActorByName(target);
-                    if (targetActor == null)
-                    {
-                        return;
-                    }
-                    targetActor.Kill(new DamageInfo(DamageInfo.DamageSourceType.FallDamage, actor, null));
-                    PushCommandChatMessage($"Killed actor {targetActor.name}", Color.green, false, false);
-                    break;
-                default:
-                    // If it's not build in command pass it to RS
-                    Plugin.logger.LogInfo("onReceiveCommand " + initCommand);
-                    RSPatch.RavenscriptEventsManagerPatch.events.onReceiveCommand.Invoke(actor, command, new bool[] { hasCommandPermission,hasRequiredArgs,local} );
-                    break;
-            }
-            if (!cmd.Global == local)
-                return;
-            using MemoryStream memoryStream = new MemoryStream();
-            var chatCommandPacket = new ChatCommandPacket
-            {
-                Id = ActorManager.instance.player.GetComponent<GuidComponent>().guid,
-                SteamID = SteamUser.GetSteamID().m_SteamID,
-                Command = CurrentChatMessage,
-                Scripted = cmd.Scripted,
-            };
-
-            using (var writer = new ProtocolWriter(memoryStream))
-            {
-                writer.Write(chatCommandPacket);
-            }
-            byte[] data = memoryStream.ToArray();
-            SendPacketToServer(data, PacketType.ChatCommand, Constants.k_nSteamNetworkingSend_Reliable);
-        }
         public void ResetState()
         {
             _ticker2 = 0f;
@@ -1014,12 +781,12 @@ namespace RavenM
 
             MarkerPosition = Vector3.zero;
 
-            CurrentChatMessage = string.Empty;
-            FullChatLink = string.Empty;
-            ChatScrollPosition = Vector2.zero;
-            JustFocused = false;
-            TypeIntention = false;
-            ChatMode = false;
+            ChatManager.instance.CurrentChatMessage = string.Empty;
+            ChatManager.instance.FullChatLink = string.Empty;
+            ChatManager.instance.ChatScrollPosition = Vector2.zero;
+            ChatManager.instance.JustFocused = false;
+            ChatManager.instance.TypeIntention = false;
+            ChatManager.instance.ChatMode = false;
 
             UsingMicrophone = false;
             PlayVoiceQueue.Clear();
@@ -1251,7 +1018,7 @@ namespace RavenM
                                 {
                                     var leaveMsg = $"{actor.name} has left the match.\n";
 
-                                    PushChatMessage(null, leaveMsg, true, -1);
+                                    ChatManager.instance.PushChatMessage(null, leaveMsg, true, -1);
 
                                     using MemoryStream memoryStream = new MemoryStream();
                                     var chatPacket = new ChatPacket
@@ -1363,7 +1130,7 @@ namespace RavenM
                                                 {
                                                     var enterMsg = $"{actor_packet.Name} has joined the match.\n";
 
-                                                    PushChatMessage(null, enterMsg, true, -1);
+                                                    ChatManager.instance.PushChatMessage(null, enterMsg, true, -1);
 
                                                     using MemoryStream memoryStream = new MemoryStream();
                                                     var chatPacket = new ChatPacket
@@ -2206,9 +1973,9 @@ namespace RavenM
 
                                     var actor = ClientActors.ContainsKey(chatPacket.Id) ? ClientActors[chatPacket.Id] : null;
                                     if (actor == null)
-                                        PushChatMessage(null, chatPacket.Message, true, -1);
+                                        ChatManager.instance.PushChatMessage(null, chatPacket.Message, true, -1);
                                     else
-                                        PushChatMessage(actor, chatPacket.Message, !chatPacket.TeamOnly, actor.team);
+                                        ChatManager.instance.PushChatMessage(actor, chatPacket.Message, !chatPacket.TeamOnly, actor.team);
                                 }
                                 break;
                             case PacketType.Voip:
@@ -2366,7 +2133,7 @@ namespace RavenM
 
                                     var actor = ClientActors.ContainsKey(commandPacket.Id) ? ClientActors[commandPacket.Id] : null;
                                     if (actor != null)
-                                        ProcessChatCommand(commandPacket.Command, actor,commandPacket.SteamID, false);
+                                        ChatManager.instance.ProcessChatCommand(commandPacket.Command, actor,commandPacket.SteamID, false);
 
                                 }
                                 break;

--- a/RavenM/IngameNetManager.cs
+++ b/RavenM/IngameNetManager.cs
@@ -32,7 +32,6 @@ namespace RavenM
                 SteamNetworkingSockets.CloseListenSocket(IngameNetManager.instance.ServerSocket);
 
             IngameNetManager.instance.ResetState();
-            ChatManager.instance.ResetChat();
         }
     }
 

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -210,6 +210,11 @@ namespace RavenM
             if (!LobbySystem.instance.InLobby || !LobbySystem.instance.LobbyDataReady || LobbySystem.instance.IsLobbyOwner || LobbySystem.instance.ModsToDownload.Count > 0)
                 return;
 
+            // Sort vehicles
+            var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
+            moddedVehicles.Sort((x, y) => x.name.CompareTo(y.name));
+            LobbySystem.instance.sortedModdedVehicles = moddedVehicles;
+
             SteamMatchmaking.SetLobbyMemberData(LobbySystem.instance.ActualLobbyID, "loaded", "yes");
         }
     }
@@ -329,6 +334,8 @@ namespace RavenM
         public bool nameTagsEnabled = true;
 
         public bool nameTagsForTeamOnly = false;
+
+        public List<GameObject> sortedModdedVehicles = new List<GameObject>();
         private void Awake()
         {
             instance = this;
@@ -389,10 +396,6 @@ namespace RavenM
 
             LobbyDataReady = true;
             ActualLobbyID = new CSteamID(pCallback.m_ulSteamIDLobby);
-
-            // Sort vehicles
-            var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
-            moddedVehicles.Sort((x, y) => x.name.CompareTo(y.name));
 
             if (IsLobbyOwner)
             {
@@ -737,7 +740,7 @@ namespace RavenM
                         if (idx == -1)
                         {
                             isDefault = false;
-                            idx = ModManager.AllVehiclePrefabs().ToList().IndexOf(prefab);
+                            idx = sortedModdedVehicles.IndexOf(prefab);
                         }
 
                         SteamMatchmaking.SetLobbyData(ActualLobbyID, i + "vehicle_" + type, prefab == null ? "NULL" : isDefault + "," + idx);
@@ -877,9 +880,8 @@ namespace RavenM
                                 newPrefab = ActorManager.instance.defaultVehiclePrefabs[idx];
                             }
                             else
-                            {
-                                var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
-                                newPrefab = moddedVehicles[idx];
+                            {    
+                                newPrefab = sortedModdedVehicles[idx];
                             }
                         }
 

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -406,6 +406,29 @@ namespace RavenM
 
                 bool needsToReload = false;
                 List<PublishedFileId_t> mods = new List<PublishedFileId_t>();
+                
+                // Sort vehicles
+                for (int i = 0; i < 2; i++)
+                {
+                    var teamInfo = GameManager.instance.gameInfo.team[i];
+
+                    foreach (var vehiclePrefab in teamInfo.vehiclePrefab)
+                    {
+                        var type = vehiclePrefab.Key;
+                        var prefab = vehiclePrefab.Value;
+
+                        // Returns -1 if the vehicle is NOT default
+                        int idx = Array.IndexOf(ActorManager.instance.defaultVehiclePrefabs, prefab);
+
+                        if (idx == -1)
+                        {
+                            // Vehicle is custom
+                            var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
+                            moddedVehicles.Sort((x, y) => x.name.CompareTo(y.name));
+                        }
+                    }
+                }
+
                 foreach (var mod in ModManager.instance.GetActiveMods())
                 {
                     if (mod.workshopItemId.ToString() == "0")
@@ -732,9 +755,7 @@ namespace RavenM
                         if (idx == -1)
                         {
                             isDefault = false;
-                            var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
-                            moddedVehicles.Sort((x, y) => x.name.CompareTo(y.name));
-                            idx = moddedVehicles.IndexOf(prefab);
+                            idx = ModManager.instance.vehiclePrefabs[type].IndexOf(prefab);
                         }
 
                         SteamMatchmaking.SetLobbyData(ActualLobbyID, i + "vehicle_" + type, prefab == null ? "NULL" : isDefault + "," + idx);

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -771,12 +771,16 @@ namespace RavenM
 
                 var enabledMutators = new List<int>();
                 ModManager.instance.loadedMutators.Sort((x, y) => x.name.CompareTo(y.name));
-                foreach (var mutator in ModManager.instance.loadedMutators)
+
+                for (int i = 0; i < ModManager.instance.loadedMutators.Count; i++)
                 {
+                    var mutator = ModManager.instance.loadedMutators.ElementAt(i);
+
                     if (!mutator.isEnabled)
                         continue;
 
-                    int id = mutator.name.GetHashCode();
+                    int id = i;
+
                     enabledMutators.Add(id);
 
                     var config = new List<string>();
@@ -942,14 +946,15 @@ namespace RavenM
 
                     int id = int.Parse(mutatorStr);
 
-                    foreach (var mutator in ModManager.instance.loadedMutators)
+                    for (int mutatorIndex = 0; mutatorIndex < ModManager.instance.loadedMutators.Count; mutatorIndex++)
                     {
-                        int candidate = mutator.name.GetHashCode();
-                        if (id == candidate)
+                        var mutator = ModManager.instance.loadedMutators.ElementAt(mutatorIndex);
+
+                        if (id == mutatorIndex)
                         {
                             mutator.isEnabled = true;
 
-                            string configStr = SteamMatchmaking.GetLobbyData(ActualLobbyID, candidate + "config");
+                            string configStr = SteamMatchmaking.GetLobbyData(ActualLobbyID, mutatorIndex + "config");
                             string pattern = "(?<!\\),";
                             string[] config = Regex.Split(configStr, pattern);
 

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -1216,6 +1216,11 @@ namespace RavenM
 
             if (InLobby && LobbyDataReady)
             {
+                if (!IngameNetManager.instance.IsClient)
+                {
+                    ChatManager.instance.CreateChatArea(true, 300f, 400f, 570f);
+                }
+
                 GUILayout.BeginArea(new Rect(10f, 10f, 150f, 10000f), string.Empty);
                 GUILayout.BeginVertical(lobbyStyle);
 
@@ -1310,11 +1315,6 @@ namespace RavenM
 
                 GUILayout.EndVertical();
                 GUILayout.EndArea();
-
-                if (!IngameNetManager.instance.IsClient)
-                {
-                    ChatManager.instance.CreateChatArea(true, 300f, 400f, 570f);
-                }
 
             }
 

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -207,13 +207,13 @@ namespace RavenM
 
             ModManager.instance.ContentChanged();
 
-            if (!LobbySystem.instance.InLobby || !LobbySystem.instance.LobbyDataReady || LobbySystem.instance.IsLobbyOwner || LobbySystem.instance.ModsToDownload.Count > 0)
-                return;
-
             // Sort vehicles
             var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
             moddedVehicles.Sort((x, y) => x.name.CompareTo(y.name));
             LobbySystem.instance.sortedModdedVehicles = moddedVehicles;
+
+            if (!LobbySystem.instance.InLobby || !LobbySystem.instance.LobbyDataReady || LobbySystem.instance.IsLobbyOwner || LobbySystem.instance.ModsToDownload.Count > 0)
+                return;
 
             SteamMatchmaking.SetLobbyMemberData(LobbySystem.instance.ActualLobbyID, "loaded", "yes");
         }

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -396,6 +396,8 @@ namespace RavenM
             LobbyDataReady = true;
             ActualLobbyID = new CSteamID(pCallback.m_ulSteamIDLobby);
 
+            ChatManager.instance.PushLobbyChatMessage($"Welcome to the lobby! Press {ChatManager.instance.GlobalChatKeybind} to chat.\n");
+
             if (IsLobbyOwner)
             {
                 OwnerID = SteamUser.GetSteamID();

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Diagnostics;
 using System.Linq;
 using RavenM.RSPatch.Wrapper;
+using System.Text.RegularExpressions;
 
 namespace RavenM
 {
@@ -781,7 +782,8 @@ namespace RavenM
                     var config = new List<string>();
                     foreach (var item in mutator.configuration.GetAllFields())
                     {
-                        config.Add(item.SerializeValue());
+                        string safeValue = item.SerializeValue().Replace(",", "\\,");
+                        config.Add(safeValue);
                     }
                     SteamMatchmaking.SetLobbyData(ActualLobbyID, id + "config", string.Join(",", config.ToArray()));
                 }
@@ -947,11 +949,14 @@ namespace RavenM
                         {
                             mutator.isEnabled = true;
 
-                            string[] config = SteamMatchmaking.GetLobbyData(ActualLobbyID, candidate + "config").Split(',');
+                            string configStr = SteamMatchmaking.GetLobbyData(ActualLobbyID, candidate + "config");
+                            string pattern = "(?<!\\),";
+                            string[] config = Regex.Split(configStr, pattern);
+
                             int i = 0;
                             foreach (var item in mutator.configuration.GetAllFields())
                             {
-                                item.DeserializeValue(config[i]);
+                                item.DeserializeValue(config[i].Replace("\\,", ","));
                                 i++;
                             }
                         }

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -880,7 +880,7 @@ namespace RavenM
                             mutator.isEnabled = true;
 
                             string configStr = SteamMatchmaking.GetLobbyData(ActualLobbyID, mutatorIndex + "config");
-                            string pattern = "(?<!\\),";
+                            string pattern = @"(?<!\),";
                             string[] config = Regex.Split(configStr, pattern);
 
                             int i = 0;
@@ -1311,7 +1311,11 @@ namespace RavenM
                 GUILayout.EndVertical();
                 GUILayout.EndArea();
 
-                ChatManager.instance.CreateChatArea(true);
+                if (!IngameNetManager.instance.IsClient)
+                {
+                    ChatManager.instance.CreateChatArea(true, 300f, 400f, 570f);
+                }
+
             }
 
             if (ModsToDownload.Count > 0)

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -231,6 +231,8 @@ namespace RavenM
             if (LobbySystem.instance.LoadedServerMods)
                 LobbySystem.instance.RequestModReload = true;
             LobbySystem.instance.IsLobbyOwner = false;
+
+            ChatManager.instance.ResetChat();
         }
     }
 

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -544,6 +544,14 @@ namespace RavenM
                     return;
                 }
             }
+
+            InstantActionMaps.instance.teamDropdown.onValueChanged.AddListener(delegate
+            {
+                OnTeamChange(InstantActionMaps.instance.teamDropdown);
+            });
+
+            // Initialize currently selected team
+            OnTeamChange(InstantActionMaps.instance.teamDropdown);
         }
 
         private void OnItemDownload(DownloadItemResult_t pCallback)
@@ -615,6 +623,11 @@ namespace RavenM
             }
         }
 
+        private void OnTeamChange(UnityEngine.UI.Dropdown dropdown)
+        {
+            SteamMatchmaking.SetLobbyMemberData(ActualLobbyID, "team", dropdown.value == 0 ? "<color=blue>E</color>" : "<color=red>R</color>");
+        }
+
         private void Update()
         {
             if (GameManager.instance == null || GameManager.IsIngame() || GameManager.IsInLoadingScreen())
@@ -658,7 +671,7 @@ namespace RavenM
             {
                 InstantActionMaps.instance.teamDropdown.value = 0;
             }
-            SteamMatchmaking.SetLobbyMemberData(ActualLobbyID, "team", InstantActionMaps.instance.teamDropdown.value == 0 ? "<color=blue>E</color>" : "<color=red>R</color>");
+            
             if (IsLobbyOwner)
             {
                 SteamMatchmaking.SetLobbyData(ActualLobbyID, "gameMode", InstantActionMaps.instance.gameModeDropdown.value.ToString());

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -882,7 +882,7 @@ namespace RavenM
                             mutator.isEnabled = true;
 
                             string configStr = SteamMatchmaking.GetLobbyData(ActualLobbyID, mutatorIndex + "config");
-                            string pattern = @"(?<!\),";
+                            string pattern = @"/(?<!\\),/g";
                             string[] config = Regex.Split(configStr, pattern);
 
                             int i = 0;
@@ -1234,6 +1234,7 @@ namespace RavenM
                     SteamMatchmaking.LeaveLobby(ActualLobbyID);
                     LobbyDataReady = false;
                     InLobby = false;
+                    ChatManager.instance.ResetChat();
                 }
 
                 GUILayout.BeginHorizontal();

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -882,7 +882,7 @@ namespace RavenM
                             mutator.isEnabled = true;
 
                             string configStr = SteamMatchmaking.GetLobbyData(ActualLobbyID, mutatorIndex + "config");
-                            string pattern = @"/(?<!\\),/g";
+                            string pattern = @"(?<!\\),";
                             string[] config = Regex.Split(configStr, pattern);
 
                             int i = 0;

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -809,47 +809,52 @@ namespace RavenM
                 {
                     InstantActionMaps.instance.teamDropdown.value = int.Parse(SteamMatchmaking.GetLobbyData(ActualLobbyID, "team"));
                 }
-                int givenEntry = int.Parse(SteamMatchmaking.GetLobbyData(ActualLobbyID, "loadedLevelEntry"));
 
-                if (givenEntry == customMapOptionIndex)
+                if (instance.LoadedServerMods)
                 {
-                    string mapName = SteamMatchmaking.GetLobbyData(ActualLobbyID, "customMap");
+                    int givenEntry = int.Parse(SteamMatchmaking.GetLobbyData(ActualLobbyID, "loadedLevelEntry"));
 
-                    if (InstantActionMaps.instance.mapDropdown.value != customMapOptionIndex || entries[customMapOptionIndex].name != mapName)
+                    if (givenEntry == customMapOptionIndex)
                     {
-                        foreach (var mod in ModManager.instance.GetActiveMods())
+                        string mapName = SteamMatchmaking.GetLobbyData(ActualLobbyID, "customMap");
+
+                        if (InstantActionMaps.instance.mapDropdown.value != customMapOptionIndex || entries[customMapOptionIndex].name != mapName)
                         {
-                            foreach (var map in mod.content.GetMaps())
+                            foreach (var mod in ModManager.instance.GetActiveMods())
                             {
-                                string currentName = string.Empty;
-                                string[] parts = map.Name.Split('.');
-                                for (int i = 0; i < parts.Length - 1; i++)
+                                foreach (var map in mod.content.GetMaps())
                                 {
-                                    currentName += parts[i];
-                                }
-                                if (currentName == mapName)
-                                {
-                                    InstantActionMaps.MapEntry entry = new InstantActionMaps.MapEntry
+                                    string currentName = string.Empty;
+                                    string[] parts = map.Name.Split('.');
+                                    for (int i = 0; i < parts.Length - 1; i++)
                                     {
-                                        name = currentName,
-                                        sceneName = map.FullName,
-                                        isCustomMap = true,
-                                        hasLoadedMetaData = true,
-                                        image = mod.content.HasIconImage()
-                                                ? Sprite.Create(mod.iconTexture, new Rect(0f, 0f, mod.iconTexture.width, mod.iconTexture.height), Vector2.zero, 100f)
-                                                : null,
-                                        suggestedBots = 0,
-                                    };
-                                    InstantActionMaps.SelectedCustomMapEntry(entry);
+                                        currentName += parts[i];
+                                    }
+                                    if (currentName == mapName)
+                                    {
+                                        InstantActionMaps.MapEntry entry = new InstantActionMaps.MapEntry
+                                        {
+                                            name = currentName,
+                                            sceneName = map.FullName,
+                                            isCustomMap = true,
+                                            hasLoadedMetaData = true,
+                                            image = mod.content.HasIconImage()
+                                                    ? Sprite.Create(mod.iconTexture, new Rect(0f, 0f, mod.iconTexture.width, mod.iconTexture.height), Vector2.zero, 100f)
+                                                    : null,
+                                            suggestedBots = 0,
+                                        };
+                                        InstantActionMaps.SelectedCustomMapEntry(entry);
+                                    }
                                 }
                             }
                         }
                     }
+                    else
+                    {
+                        InstantActionMaps.instance.mapDropdown.value = givenEntry;
+                    }
                 }
-                else
-                {
-                    InstantActionMaps.instance.mapDropdown.value = givenEntry;
-                }
+
 
                 for (int i = 0; i < 2; i++)
                 {
@@ -1270,10 +1275,6 @@ namespace RavenM
                     if (Plugin.BuildGUID != SteamMatchmaking.GetLobbyData(LobbyView, "build_id"))
                     {
                         GUILayout.Label("<color=red>This lobby is running on a different version of RavenM!</color>");
-                    }
-                    else if (ModManager.instance.noContentMods && modCount > 0)
-                    {
-                        GUILayout.Label("<color=red>Lobby is using mods! Please run Ravenfield with mods enabled to join.</color>");
                     }
                     else if (GUILayout.Button("JOIN"))
                     {

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -1258,6 +1258,10 @@ namespace RavenM
                     {
                         GUILayout.Label("<color=red>This lobby is running on a different version of RavenM!</color>");
                     }
+                    else if (ModManager.instance.noContentMods && modCount > 0)
+                    {
+                        GUILayout.Label("<color=red>Lobby is using mods! Please run Ravenfield with mods enabled to join.</color>");
+                    }
                     else if (GUILayout.Button("JOIN"))
                     {
                         SteamMatchmaking.JoinLobby(LobbyView);

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -30,6 +30,7 @@ namespace RavenM
             if (LobbySystem.instance.InLobby && !LobbySystem.instance.IsLobbyOwner && !LobbySystem.instance.ReadyToPlay)
                 return false;
             OptionsPatch.SetConfigValues(false);
+
             // Only start if all members are ready.
             if (LobbySystem.instance.LobbyDataReady && LobbySystem.instance.IsLobbyOwner)
             {
@@ -48,6 +49,7 @@ namespace RavenM
 
                 SteamMatchmaking.SetLobbyData(LobbySystem.instance.ActualLobbyID, "started", "yes");
             }
+
             LobbySystem.instance.ReadyToPlay = false;
             return true;
         }
@@ -255,7 +257,9 @@ namespace RavenM
                 return;
 
             if (LobbySystem.instance.IsLobbyOwner)
+            {
                 SteamMatchmaking.SetLobbyData(LobbySystem.instance.ActualLobbyID, "started", "false");
+            }
 
             SteamMatchmaking.SetLobbyMemberData(LobbySystem.instance.ActualLobbyID, "ready", "no");
         }
@@ -433,6 +437,7 @@ namespace RavenM
                 SteamMatchmaking.SetLobbyData(ActualLobbyID, "owner", OwnerID.ToString());
                 SteamMatchmaking.SetLobbyData(ActualLobbyID, "mods", string.Join(",", mods.ToArray()));
                 SteamMatchmaking.SetLobbyMemberData(ActualLobbyID, "loaded", "yes");
+                SteamMatchmaking.SetLobbyData(ActualLobbyID, "started", "false");
             }
             else
             {
@@ -1356,7 +1361,7 @@ namespace RavenM
 
                     GUILayout.BeginHorizontal();
                     GUILayout.FlexibleSpace();
-                    GUILayout.Label($"{punBytesDownloaded / 1024}KB/{punBytesTotal / 1024}KB");
+                    GUILayout.Label($"{Math.Round( punBytesDownloaded / Math.Pow(1024, 2), 2 )}MB/{Math.Round( punBytesTotal / Math.Pow(1024, 2), 2)}MB");
                     GUILayout.FlexibleSpace();
                     GUILayout.EndHorizontal();
 

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -390,6 +390,10 @@ namespace RavenM
             LobbyDataReady = true;
             ActualLobbyID = new CSteamID(pCallback.m_ulSteamIDLobby);
 
+            // Sort vehicles
+            var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
+            moddedVehicles.Sort((x, y) => x.name.CompareTo(y.name));
+
             if (IsLobbyOwner)
             {
                 OwnerID = SteamUser.GetSteamID();
@@ -406,28 +410,6 @@ namespace RavenM
 
                 bool needsToReload = false;
                 List<PublishedFileId_t> mods = new List<PublishedFileId_t>();
-                
-                // Sort vehicles
-                for (int i = 0; i < 2; i++)
-                {
-                    var teamInfo = GameManager.instance.gameInfo.team[i];
-
-                    foreach (var vehiclePrefab in teamInfo.vehiclePrefab)
-                    {
-                        var type = vehiclePrefab.Key;
-                        var prefab = vehiclePrefab.Value;
-
-                        // Returns -1 if the vehicle is NOT default
-                        int idx = Array.IndexOf(ActorManager.instance.defaultVehiclePrefabs, prefab);
-
-                        if (idx == -1)
-                        {
-                            // Vehicle is custom
-                            var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
-                            moddedVehicles.Sort((x, y) => x.name.CompareTo(y.name));
-                        }
-                    }
-                }
 
                 foreach (var mod in ModManager.instance.GetActiveMods())
                 {
@@ -755,7 +737,7 @@ namespace RavenM
                         if (idx == -1)
                         {
                             isDefault = false;
-                            idx = ModManager.instance.vehiclePrefabs[type].IndexOf(prefab);
+                            idx = ModManager.AllVehiclePrefabs().ToList().IndexOf(prefab);
                         }
 
                         SteamMatchmaking.SetLobbyData(ActualLobbyID, i + "vehicle_" + type, prefab == null ? "NULL" : isDefault + "," + idx);
@@ -897,7 +879,6 @@ namespace RavenM
                             else
                             {
                                 var moddedVehicles = ModManager.AllVehiclePrefabs().ToList();
-                                moddedVehicles.Sort((x, y) => x.name.CompareTo(y.name));
                                 newPrefab = moddedVehicles[idx];
                             }
                         }
@@ -930,7 +911,6 @@ namespace RavenM
                             else
                             {
                                 var moddedTurrets = ModManager.AllTurretPrefabs().ToList();
-                                moddedTurrets.Sort((x, y) => x.name.CompareTo(y.name));
                                 newPrefab = moddedTurrets[idx];
                             }
                         }

--- a/RavenM/OptionsPatch.cs
+++ b/RavenM/OptionsPatch.cs
@@ -105,8 +105,8 @@ namespace RavenM
             IngameNetManager.instance.VoiceChatVolume = GetOptionWithName<float>(RavenMOptions.VoiceChatVolume, OptionTypes.Slider);
             IngameNetManager.instance.VoiceChatKeybind = setKeybinds[OptionKeybind.VoiceChatButton].Value;
             IngameNetManager.instance.PlaceMarkerKeybind = setKeybinds[OptionKeybind.PlaceMarkerButton].Value;
-            IngameNetManager.instance.GlobalChatKeybind = setKeybinds[OptionKeybind.GlobalChatButton].Value;
-            IngameNetManager.instance.TeamChatKeybind = setKeybinds[OptionKeybind.TeamChatButton].Value;
+            ChatManager.instance.GlobalChatKeybind = setKeybinds[OptionKeybind.GlobalChatButton].Value;
+            ChatManager.instance.TeamChatKeybind = setKeybinds[OptionKeybind.TeamChatButton].Value;
             onSettingUpdate?.Invoke();
         }
         public static T GetOptionWithName<T>(RavenMOptions option, OptionTypes type)

--- a/RavenM/Plugin.cs
+++ b/RavenM/Plugin.cs
@@ -76,7 +76,7 @@ namespace RavenM
 
             configRavenMDevMod = Config.Bind("General.Toggles",
                                                 "Enable Dev Mode",
-                                                true,
+                                                false,
                                                 "Change GUID to bb3ef199-df63-4e99-a8a1-89a27d9e2fcb");
             configRavenMAddToBuiltInMutators = Config.Bind("General.Toggles",
                 "Enable Custom Build In Mutators",

--- a/RavenM/Plugin.cs
+++ b/RavenM/Plugin.cs
@@ -76,7 +76,7 @@ namespace RavenM
 
             configRavenMDevMod = Config.Bind("General.Toggles",
                                                 "Enable Dev Mode",
-                                                false,
+                                                true,
                                                 "Change GUID to bb3ef199-df63-4e99-a8a1-89a27d9e2fcb");
             configRavenMAddToBuiltInMutators = Config.Bind("General.Toggles",
                 "Enable Custom Build In Mutators",

--- a/RavenM/Plugin.cs
+++ b/RavenM/Plugin.cs
@@ -1,8 +1,10 @@
-﻿using BepInEx;
+﻿using System;
+using BepInEx;
 using BepInEx.Configuration;
 using HarmonyLib;
 using Steamworks;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using UnityEngine;
 namespace RavenM
@@ -49,7 +51,10 @@ namespace RavenM
         public static bool addToBuiltInMutators = false;
         public static string customBuildInMutators;
         public static List<string> customMutatorsDirectories = new List<string>();
-        
+
+        public static bool JoinedLobbyFromArgument = false;
+        public static Dictionary<string, string> Arguments = new Dictionary<string, string>();
+
         public static string BuildGUID
         {
             get
@@ -102,8 +107,23 @@ namespace RavenM
             }
             var harmony = new Harmony("patch.ravenm");
             harmony.PatchAll();
-
-
+            
+            string[] args = Environment.GetCommandLineArgs();
+            foreach (var argument in args)
+            {
+                if (argument.Contains("="))
+                {
+                    string[] argumentVals = argument.Split('=');
+                    string argumentName = argumentVals[0];
+                    string argumentValue = argumentVals[1];
+                    Arguments.Add(argumentName, argumentValue);
+                }
+                else
+                {
+                    Arguments.Add(argument, "");
+                }
+            }
+            
             // Test code
         }
         private void OnGUI()
@@ -140,6 +160,20 @@ namespace RavenM
                 discordObject.AddComponent<DiscordIntegration>();
                 DontDestroyOnLoad(discordObject);
             }
+            else if (!JoinedLobbyFromArgument && Arguments.ContainsKey("-ravenm-lobby"))
+            {
+                JoinLobbyFromArgument();
+            }
+        }
+
+        void JoinLobbyFromArgument()
+        {
+            JoinedLobbyFromArgument = true;
+            CSteamID lobbyId = new CSteamID(ulong.Parse(Arguments["-ravenm-lobby"]));
+            SteamMatchmaking.JoinLobby(lobbyId);
+            LobbySystem.instance.InLobby = true;
+            LobbySystem.instance.IsLobbyOwner = false;
+            LobbySystem.instance.LobbyDataReady = false;
         }
     }
 }

--- a/RavenM/Plugin.cs
+++ b/RavenM/Plugin.cs
@@ -128,6 +128,10 @@ namespace RavenM
                 lobbyObject.AddComponent<LobbySystem>();
                 DontDestroyOnLoad(lobbyObject);
 
+                var chatObject = new GameObject();
+                chatObject.AddComponent<ChatManager>();
+                DontDestroyOnLoad(chatObject);
+
                 var netObject = new GameObject();
                 netObject.AddComponent<IngameNetManager>();
                 DontDestroyOnLoad(netObject);

--- a/RavenM/ProtocolStream.cs
+++ b/RavenM/ProtocolStream.cs
@@ -480,7 +480,6 @@ namespace RavenM
             Write(value.Command);
             Write(value.Scripted);
         }
-
     }
 
     public class ProtocolReader : BinaryReader

--- a/RavenM/RavenM.csproj
+++ b/RavenM/RavenM.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+    <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.Core" Version="(,6)" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="(,2)" />
     <PackageReference Include="UnityEngine.Modules" Version="5.6.0" IncludeAssets="compile" />
   </ItemGroup>
   

--- a/RavenM/RavenM.csproj
+++ b/RavenM/RavenM.csproj
@@ -28,8 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Core" Version="(,6)" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="(,2)" />
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.1.0" />
     <PackageReference Include="UnityEngine.Modules" Version="5.6.0" IncludeAssets="compile" />
   </ItemGroup>
   

--- a/RavenM/rspatch/Proxy/WOnlinePlayerProxy.cs
+++ b/RavenM/rspatch/Proxy/WOnlinePlayerProxy.cs
@@ -50,11 +50,11 @@ namespace RavenM.RSPatch.Proxy
 
         public static void PushChatMessage(string message)
         {
-            IngameNetManager.instance.PushChatMessage(ActorManager.instance.player, message,true, -1);
+            ChatManager.instance.PushChatMessage(ActorManager.instance.player, message,true, -1);
         }
         public static void PushCommandChatMessage(string message,Color color,bool teamOnly,bool sendToAll)
         {
-            IngameNetManager.instance.PushCommandChatMessage(message, color, teamOnly, sendToAll);
+            ChatManager.instance.PushCommandChatMessage(message, color, teamOnly, sendToAll);
         }
         [MoonSharpHidden]
         public object GetValue()

--- a/RavenM/rspatch/Wrapper/WLobby.cs
+++ b/RavenM/rspatch/Wrapper/WLobby.cs
@@ -53,7 +53,7 @@ namespace RavenM.RSPatch.Wrapper
                 return;
             }
             string input = $"<b>Server</b> <color=#{ColorUtility.ToHtmlStringRGB(color)}>{message}</color>";
-            IngameNetManager.instance.PushChatMessage(null, input, true, -1);
+            ChatManager.instance.PushChatMessage(null, input, true, -1);
             
             using MemoryStream memoryStream = new MemoryStream();
             var chatPacket = new ChatPacket


### PR DESCRIPTION
Creates a new ChatManager class that handles the chat menu (no longer a part of the IngameNetManager).
ChatManager should also handle commands in the lobby separately from commands in-game (i.e commands such as /kill are not part of the commands allowed in the lobby)