### PR TITLE
Scripted Mission Trigger On Start Check

### DIFF
--- a/RavenM/Plugin.cs
+++ b/RavenM/Plugin.cs
@@ -61,7 +61,7 @@ namespace RavenM
             {
                 if (!changeGUID)
                 {
-                    return $"STABLE-0-7-{Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId.ToString().Split('-').Last()}";
+                    return $"INDEV-0-7-{Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId.ToString().Split('-').Last()}";
                 }
                 else
                 {

--- a/RavenM/gamemode/ScriptedStatePacket.cs
+++ b/RavenM/gamemode/ScriptedStatePacket.cs
@@ -1,0 +1,76 @@
+﻿using HarmonyLib;
+using Ravenfield.Trigger;
+using System.Collections;
+using System.Collections.Generic;
+using Steamworks;
+using System.Linq;
+namespace RavenM
+{
+    [HarmonyPatch(typeof(ScriptedGameMode), "StartGame")]
+    public class ScriptedMissionPlayerCheckPatch
+    {
+        public static List<TriggerOnStart> triggerOnStart = new List<TriggerOnStart>();
+
+        public static bool ready = false;
+
+
+        static bool Prefix(ScriptedGameMode __instance)
+        {
+            if (IngameNetManager.instance.IsClient && !IngameNetManager.instance.IsHost)
+                return false;
+            if (ready)
+            {
+                ChatManager.instance.PushCommandChatMessage("Starting Scripted Mission!", UnityEngine.Color.white, false, true);
+                foreach (TriggerOnStart triggerOnStart in triggerOnStart)
+                {
+                    if (triggerOnStart != null)
+                    {
+                        triggerOnStart.Start();
+                    }
+                }
+                triggerOnStart.Clear();
+                return true;
+            }
+            __instance.StartCoroutine(WaitForPlayers(__instance));
+            return false;
+        }
+
+        public static IEnumerator WaitForPlayers(ScriptedGameMode gamemode)
+        {
+            ready = false;
+            while (LobbySystem.instance.GetLobbyMembers().Any(x => SteamMatchmaking.GetLobbyMemberData(LobbySystem.instance.ActualLobbyID, x, "loaded") != "yes")) //wait until everyone is in the scene
+            {
+                yield return null;
+            }            
+            ready = true;
+            yield return null;
+
+
+            gamemode.StartGame();
+            yield break;
+        }
+
+    }
+    [HarmonyPatch(typeof(TriggerOnStart), "Start")]
+    public class ScriptedMissionStartPatch
+    {
+        static bool Prefix(TriggerOnStart __instance)
+        {
+            if (IngameNetManager.instance.IsHost)
+            {
+                if (GameModeBase.activeGameMode is ScriptedGameMode && __instance.type == TriggerOnStart.Type.OnStart)
+                {
+                    if (ScriptedMissionPlayerCheckPatch.ready)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        ScriptedMissionPlayerCheckPatch.triggerOnStart.Add(__instance);
+                    }
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/RavenM/gamemode/ScriptedStatePacket.cs
+++ b/RavenM/gamemode/ScriptedStatePacket.cs
@@ -29,6 +29,7 @@ namespace RavenM
                     }
                 }
                 triggerOnStart.Clear();
+                ready = false;
                 return true;
             }
             __instance.StartCoroutine(WaitForPlayers(__instance));


### PR DESCRIPTION
Many scripted missions spawn the player immediately on start.
If clients aren't able to enter the scene before the host does, they might not have a chance to spawn in with the host.

This delays both on spawn triggers and checkpoint triggers until all players are loaded into the scene